### PR TITLE
Don't break parsing when headers end in newlines and carriage returns

### DIFF
--- a/lib/mail/fields/references_field.rb
+++ b/lib/mail/fields/references_field.rb
@@ -37,7 +37,7 @@ module Mail
 
     def initialize(value = nil, charset = nil)
       value = value.join("\r\n\s") if value.is_a?(Array)
-      super value, charset
+      super value&.chomp, charset
     end
   end
 end

--- a/spec/mail/fields/references_field_spec.rb
+++ b/spec/mail/fields/references_field_spec.rb
@@ -70,4 +70,9 @@ describe Mail::ReferencesField do
     m = Mail::ReferencesField.new( '2a26f8f146e27159@domain.com@domain.com 4769770500E92399@n064.sc1.he.tucows.com' )
     expect(m.message_ids).to eq [ '2a26f8f146e27159@domain.com@domain.com', '4769770500E92399@n064.sc1.he.tucows.com' ]
   end
+
+  it 'should be able to parse new lines' do
+    m = Mail::ReferencesField.new("<foo@mail.gmail.com>,<bar@prod.outlook.com>\r\n")
+    expect(m.message_ids).to eq ["foo@mail.gmail.com", "bar@prod.outlook.com"]
+  end
 end


### PR DESCRIPTION
We have hundreds of emails that have `\r\n` at the end of the header . This is parsed incorrectly in the Mail gem. 

Ideally we would change the Ragel parsing to do the right thing, but I don't have time to learn Ragel at the moment. 