### PR TITLE
Preserve existing range behavior for Ruby 2.7

### DIFF
--- a/lib/mail/multibyte/unicode.rb
+++ b/lib/mail/multibyte/unicode.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "mail/utilities"
+
 module Mail
   module Multibyte
     module Unicode
@@ -128,6 +130,7 @@ module Mail
               (database.boundary[:extend] === current)
             )
           else
+            Mail::Utilities.raise_on_beginless_range(marker, pos-1)
             unpacked << codepoints[marker..pos-1]
             marker = pos
           end
@@ -203,6 +206,7 @@ module Mail
                 j = starter_pos + 1
                 eoa -= 1
               end
+              Mail::Utilities.raise_on_beginless_range(starter_pos, j)
               codepoints[starter_pos..j] = (lindex * HANGUL_VCOUNT + vindex) * HANGUL_TCOUNT + tindex + HANGUL_SBASE
             end
             starter_pos += 1

--- a/lib/mail/parser_tools.rb
+++ b/lib/mail/parser_tools.rb
@@ -1,13 +1,17 @@
+require "mail/utilities"
+
 module Mail
   # Extends each field parser with utility methods.
   module ParserTools #:nodoc:
     # Slice bytes from ASCII-8BIT data and mark as UTF-8.
     if 'string'.respond_to?(:force_encoding)
       def chars(data, from_bytes, to_bytes)
+        Mail::Utilities.raise_on_beginless_range(from_bytes, to_bytes)
         data.slice(from_bytes..to_bytes).force_encoding(Encoding::UTF_8)
       end
     else
       def chars(data, from_bytes, to_bytes)
+        Mail::Utilities.raise_on_beginless_range(from_bytes, to_bytes)
         data.slice(from_bytes..to_bytes)
       end
     end

--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -327,7 +327,7 @@ module Mail
 
       if stop.nil?
         # technically, Ruby <v2.7 will not raise on this scenario until it is used
-        # --that is `x = nil..nil` won't raise but `x = nil..nil; 'hello'[x]`
+        # --that is `x = nil..nil` won't raise but `x = nil..nil; 'hello'[x]` will
         raise TypeError, 'no implicit conversion from nil to integer'
       else
         raise ArgumentError, 'bad value for range'

--- a/lib/mail/utilities.rb
+++ b/lib/mail/utilities.rb
@@ -320,5 +320,18 @@ module Mail
         value.respond_to?(:empty?) ? value.empty? : !value
       end
     end
+
+    # simulate old Ruby range behavior (Ruby <v2.7 doesn't allow "beginless" ranges)
+    def self.raise_on_beginless_range(start, stop)
+      return unless start.nil?
+
+      if stop.nil?
+        # technically, Ruby <v2.7 will not raise on this scenario until it is used
+        # --that is `x = nil..nil` won't raise but `x = nil..nil; 'hello'[x]`
+        raise TypeError, 'no implicit conversion from nil to integer'
+      else
+        raise ArgumentError, 'bad value for range'
+      end
+    end
   end
 end

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -527,4 +527,16 @@ describe "Utilities Module" do
       end
     end
   end
+
+  describe "raise_on_beginless_range" do
+    it "throws an ArgumentError for nil..x" do
+      expect { Mail::Utilities.raise_on_beginless_range(nil, 1) }
+        .to raise_error ArgumentError
+    end
+
+    it "throws a TypeError for nil..nil" do
+      expect { Mail::Utilities.raise_on_beginless_range(nil, nil) }
+        .to raise_error TypeError
+    end
+  end
 end

--- a/spec/mail/utilities_spec.rb
+++ b/spec/mail/utilities_spec.rb
@@ -538,5 +538,15 @@ describe "Utilities Module" do
       expect { Mail::Utilities.raise_on_beginless_range(nil, nil) }
         .to raise_error TypeError
     end
+
+    it "does not throw an error for x..nil" do
+      expect { Mail::Utilities.raise_on_beginless_range(1, nil) }
+        .not_to raise_error
+    end
+
+    it "does not throw an error for x..y" do
+      expect { Mail::Utilities.raise_on_beginless_range(1, 2) }
+        .not_to raise_error
+    end
   end
 end

--- a/tasks/generate_tables
+++ b/tasks/generate_tables
@@ -5,6 +5,7 @@
 #   ruby tasks/generate_tables
 # The Unicode version downloaded is determined by the UNICODE_VERSION lib/mail/multibye/unicode.rb
 require './lib/mail/multibyte/unicode'
+require './lib/mail/utilities'
 
 require 'open-uri'
 require 'tmpdir'
@@ -69,6 +70,8 @@ module Mail
             @ucd.boundary[type] ||= []
             if $1.include? '..'
               parts = $1.split '..'
+
+              Mail::Utilities.raise_on_beginless_range(parts[0].hex, parts[1].hex)
               @ucd.boundary[type] << (parts[0].hex..parts[1].hex)
             else
               @ucd.boundary[type] << $1.hex


### PR DESCRIPTION
Ruby 2.7 [introduces "beginless" ranges](https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/). A neat feature, but some of our code relies on an exception being thrown when a range begins with nil.

Explored the edge cases, and this is what I found:
```
> ASDF_RUBY_VERSION=2.6.9 ruby range_test.rb


nil..1
  ArgumentError, "bad value for range"
nil..nil
nil..
'hi'[nil..1]
  ArgumentError, "bad value for range"
'hi'[nil..nil]
  TypeError, "no implicit conversion from nil to integer"
'hi'[nil..]
  TypeError, "no implicit conversion from nil to integer"

x = nil; x..1
  ArgumentError, "bad value for range"
x = nil; x..x
x = nil; x..
x = nil; 'hi'[x..1]
  ArgumentError, "bad value for range"
x = nil; 'hi'[x..x]
  TypeError, "no implicit conversion from nil to integer"
x = nil; 'hi'[x..]
  TypeError, "no implicit conversion from nil to integer"


nil...1
  ArgumentError, "bad value for range"
nil...nil
nil...
'hi'[nil...1]
  ArgumentError, "bad value for range"
'hi'[nil...nil]
  TypeError, "no implicit conversion from nil to integer"
'hi'[nil...]
  TypeError, "no implicit conversion from nil to integer"

x = nil; x...1
  ArgumentError, "bad value for range"
x = nil; x...x
x = nil; x...
x = nil; 'hi'[x...1]
  ArgumentError, "bad value for range"
x = nil; 'hi'[x...x]
  TypeError, "no implicit conversion from nil to integer"
x = nil; 'hi'[x...]
  TypeError, "no implicit conversion from nil to integer"


false..1
  ArgumentError, "bad value for range"
false..false
false..
'hi'[false..1]
  ArgumentError, "bad value for range"
'hi'[false..false]
  TypeError, "no implicit conversion of false into Integer"
'hi'[false..]
  TypeError, "no implicit conversion of false into Integer"

x = false; x..1
  ArgumentError, "bad value for range"
x = false; x..x
x = false; x..
x = false; 'hi'[x..1]
  ArgumentError, "bad value for range"
x = false; 'hi'[x..x]
  TypeError, "no implicit conversion of false into Integer"
x = false; 'hi'[x..]
  TypeError, "no implicit conversion of false into Integer"


false...1
  ArgumentError, "bad value for range"
false...false
false...
'hi'[false...1]
  ArgumentError, "bad value for range"
'hi'[false...false]
  TypeError, "no implicit conversion of false into Integer"
'hi'[false...]
  TypeError, "no implicit conversion of false into Integer"

x = false; x...1
  ArgumentError, "bad value for range"
x = false; x...x
x = false; x...
x = false; 'hi'[x...1]
  ArgumentError, "bad value for range"
x = false; 'hi'[x...x]
  TypeError, "no implicit conversion of false into Integer"
x = false; 'hi'[x...]
  TypeError, "no implicit conversion of false into Integer"
```

```
> ASDF_RUBY_VERSION=2.7.5 ruby range_test.rb


nil..1
nil..nil
nil..
'hi'[nil..1]
'hi'[nil..nil]
'hi'[nil..]

x = nil; x..1
x = nil; x..x
x = nil; x..
x = nil; 'hi'[x..1]
x = nil; 'hi'[x..x]
x = nil; 'hi'[x..]


nil...1
nil...nil
nil...
(eval):1: warning: ... at EOL, should be parenthesized?
'hi'[nil...1]
'hi'[nil...nil]
'hi'[nil...]

x = nil; x...1
x = nil; x...x
x = nil; x...
(eval):1: warning: ... at EOL, should be parenthesized?
x = nil; 'hi'[x...1]
x = nil; 'hi'[x...x]
x = nil; 'hi'[x...]


false..1
  ArgumentError, "bad value for range"
false..false
false..
'hi'[false..1]
  ArgumentError, "bad value for range"
'hi'[false..false]
  TypeError, "no implicit conversion of false into Integer"
'hi'[false..]
  TypeError, "no implicit conversion of false into Integer"

x = false; x..1
  ArgumentError, "bad value for range"
x = false; x..x
x = false; x..
x = false; 'hi'[x..1]
  ArgumentError, "bad value for range"
x = false; 'hi'[x..x]
  TypeError, "no implicit conversion of false into Integer"
x = false; 'hi'[x..]
  TypeError, "no implicit conversion of false into Integer"


false...1
  ArgumentError, "bad value for range"
false...false
false...
(eval):1: warning: ... at EOL, should be parenthesized?
'hi'[false...1]
  ArgumentError, "bad value for range"
'hi'[false...false]
  TypeError, "no implicit conversion of false into Integer"
'hi'[false...]
  TypeError, "no implicit conversion of false into Integer"

x = false; x...1
  ArgumentError, "bad value for range"
x = false; x...x
x = false; x...
(eval):1: warning: ... at EOL, should be parenthesized?
x = false; 'hi'[x...1]
  ArgumentError, "bad value for range"
x = false; 'hi'[x...x]
  TypeError, "no implicit conversion of false into Integer"
x = false; 'hi'[x...]
  TypeError, "no implicit conversion of false into Integer"
```

Here's the script that I used for the above + my findings and solution:
```
Wrapper = Struct.new(:prefix, :suffix)

def try_it code
  puts code
  eval code
rescue => e
  puts "  #{e.class}, #{e.message.inspect}"
end

['nil', 'false'].each do |falsey|
  ['..', '...'].each do |dots|
    puts
    [Wrapper.new, Wrapper.new("'hi'[", "]")].each do |wrapper|
      ["#{falsey}#{dots}1", "#{falsey}#{dots}#{falsey}", "#{falsey}#{dots}"].each do |range|
        try_it "#{wrapper.prefix}#{range}#{wrapper.suffix}"
      end
    end
    
    puts
    [Wrapper.new("x = #{falsey}; "), Wrapper.new("x = #{falsey}; 'hi'[", "]")].each do |wrapper|
      ["x#{dots}1", "x#{dots}x", "x#{dots}"].each do |range|
        try_it "#{wrapper.prefix}#{range}#{wrapper.suffix}"
      end
    end
    
    puts
  end
end



=begin


FINDING:

nil..non-nil is always, immediately:
  ArgumentError, "bad value for range"

nil..nil or nil..
will /eventually/ be 
  TypeError, "no implicit conversion from nil to integer"
(that is, by itself, it won't throw, but once you try to *use* the range (like putting the range in []s), it will throw the TypeError)



SOLUTION:

given range a..b



# simulate old Ruby range behavior (Ruby <v2.7 doesn't allow "beginless" ranges)
def self.raise_on_beginless_range(start, stop)
  return unless start.nil?

  if stop.nil?
    # technically, Ruby <v2.7 will not raise on this scenario until it is used
    # --that is `x = nil..nil` won't raise but `x = nil..nil; 'hello'[x]`
    raise TypeError, 'no implicit conversion from nil to integer'
  else
    raise ArgumentError, 'bad value for range'
  end
end


=end
```